### PR TITLE
feat: more generic postinstall

### DIFF
--- a/.changeset/odd-comics-compare.md
+++ b/.changeset/odd-comics-compare.md
@@ -1,0 +1,6 @@
+---
+"@inkathon/contracts": patch
+"@inkathon/frontend": patch
+---
+
+allow postinstall to work with new contracts instead of only packaged greeter

--- a/contracts/postinstall.sh
+++ b/contracts/postinstall.sh
@@ -5,13 +5,20 @@ set -eu
 # This is kind of a hack to prevent a nasty Next.js error when running the frontend
 # for the first time after deploying to a local node which forces to clear `frontend/.next`.
 
-if [[ ! -e deployments/greeter/development.ts ]]; then
-    echo "Creating empty 'development.ts'…"
-    if command -v touch &> /dev/null; then
-        touch deployments/greeter/development.ts
+for dir in "./src/"*/; do
+    contract_name=$(basename "${dir}")
+
+    if [[ ! -e "./deployments/${contract_name}/development.ts" ]]; then
+        echo "Creating empty 'development.ts' file for ${contract_name}"
+
+        mkdir -p "./deployments/${contract_name}"
+
+        if command -v touch &>/dev/null; then
+            touch "./deployments/${contract_name}/development.ts"
+        else
+            copy /b "deployments/${contract_name}/development.ts" +,,
+        fi
     else
-        copy /b deployments/greeter/development.ts +,,
+        echo "Great, 'development.ts' already exists! Skipping…"
     fi
-else
-    echo "Great, 'development.ts' already exists! Skipping…"
-fi
+done


### PR DESCRIPTION
makes postinstall work with folder names of contracts as it's hardcoded for `greeter` contract.