### PR TITLE
Update pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "engines": {
     "node": ">=18 <=20",
-    "pnpm": "8"
+    "pnpm": ">=8"
   },
   "scripts": {
     "dev": "pnpm run -F frontend dev",


### PR DESCRIPTION
When running

`npm run dev`

I get

```bash
> dev
> pnpm run -F frontend dev

 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your pnpm version is incompatible with "/Users/no/code/inkathon".

Expected version: 8
Got: 9.0.2

This is happening because the package's manifest has an engines.pnpm field specified.
To fix this issue, install the required pnpm version globally.

To install the latest version of pnpm, run "pnpm i -g pnpm".
To check your pnpm version, run "pnpm -v".
```

adding a `>=` makes it runnable with 9.0.2 and i assume it is a safe alteration